### PR TITLE
feat: introduce products module with matching nodes integration

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
 
 import { SessionsModule } from './modules/codex/sessions/sessions.module';
+import { ProductsModule } from './modules/products/products.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { SessionsModule } from './modules/codex/sessions/sessions.module';
       }),
     }),
     SessionsModule,
+    ProductsModule,
   ],
 })
 export class AppModule {}

--- a/src/modules/products/dto/create-product.dto.ts
+++ b/src/modules/products/dto/create-product.dto.ts
@@ -1,0 +1,57 @@
+import { Type } from 'class-transformer';
+import {
+  IsISO8601,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUrl,
+} from 'class-validator';
+
+export class CreateProductDto {
+  @IsString()
+  @IsNotEmpty()
+  nombre!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  marca!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  img!: string;
+
+  @Type(() => Number)
+  @IsNumber()
+  precioFinal!: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  precioLista!: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  precioKiloLitro!: number;
+
+  @IsString()
+  @IsNotEmpty()
+  categoria!: string;
+
+  @IsOptional()
+  @IsString()
+  subcategoria?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  ean!: string;
+
+  @IsISO8601()
+  scrapedate!: string;
+
+  @IsUrl()
+  url_producto!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  sitio!: string;
+}

--- a/src/modules/products/dto/match-product.dto.ts
+++ b/src/modules/products/dto/match-product.dto.ts
@@ -1,0 +1,15 @@
+import { Type } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsString, ValidateNested } from 'class-validator';
+
+import { CreateProductDto } from './create-product.dto';
+
+export class MatchProductDto {
+  @ValidateNested()
+  @Type(() => CreateProductDto)
+  product!: CreateProductDto;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  nodeIds!: string[];
+}

--- a/src/modules/products/entities/product.entity.ts
+++ b/src/modules/products/entities/product.entity.ts
@@ -1,0 +1,43 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'products' })
+export class Product {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  nombre!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  marca!: string;
+
+  @Column({ type: 'varchar', length: 1024 })
+  img!: string;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2, nullable: true })
+  precioFinal!: number;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2, nullable: true })
+  precioLista!: number;
+
+  @Column({ type: 'decimal', precision: 12, scale: 4, nullable: true })
+  precioKiloLitro!: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  categoria!: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  subcategoria!: string;
+
+  @Column({ type: 'varchar', length: 32 })
+  ean!: string;
+
+  @Column({ type: 'timestamptz' })
+  scrapedate!: Date;
+
+  @Column({ type: 'varchar', length: 1024 })
+  url_producto!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  sitio!: string;
+}

--- a/src/modules/products/matching.service.ts
+++ b/src/modules/products/matching.service.ts
@@ -1,0 +1,84 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { AxiosError } from 'axios';
+import { firstValueFrom } from 'rxjs';
+
+import { CreateProductDto } from './dto/create-product.dto';
+import { MatchingNode, MatchingNodeRepository } from './nodes.repository';
+
+interface MatchResult {
+  matches: unknown[];
+}
+
+@Injectable()
+export class MatchingService {
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly nodeRepository: MatchingNodeRepository,
+  ) {}
+
+  async matchProduct(
+    product: CreateProductDto,
+    nodeIds: string[],
+  ): Promise<Record<string, MatchResult>> {
+    const nodes = nodeIds.map((nodeId) => {
+      const node = this.nodeRepository.findById(nodeId);
+      if (!node) {
+        throw new NotFoundException(`Matching node ${nodeId} not found`);
+      }
+      return node;
+    });
+
+    const results: Record<string, MatchResult> = {};
+
+    await Promise.all(
+      nodes.map(async (node) => {
+        try {
+          const response = await firstValueFrom(
+            this.httpService.post(`http://${node.host}:${node.port}/match`, product),
+          );
+
+          results[node.id] = this.normalizeNodeResponse(response.data);
+        } catch (error) {
+          results[node.id] = {
+            matches: this.buildSimulatedMatches(product, node, error as AxiosError),
+          };
+        }
+      }),
+    );
+
+    return results;
+  }
+
+  private normalizeNodeResponse(data: unknown): MatchResult {
+    if (data && typeof data === 'object' && 'matches' in (data as Record<string, unknown>)) {
+      const matches = (data as Record<string, unknown>).matches;
+      if (Array.isArray(matches)) {
+        return { matches };
+      }
+    }
+
+    if (Array.isArray(data)) {
+      return { matches: data };
+    }
+
+    return { matches: [data] };
+  }
+
+  private buildSimulatedMatches(
+    product: CreateProductDto,
+    node: MatchingNode,
+    error: AxiosError,
+  ): unknown[] {
+    const message = error?.message ?? 'Unknown error';
+    return [
+      {
+        title: `Simulated match for ${product.nombre}`,
+        ean: product.ean,
+        node: node.type,
+        confidence: 0,
+        reason: `Fallback due to error contacting node: ${message}`,
+      },
+    ];
+  }
+}

--- a/src/modules/products/nodes.repository.ts
+++ b/src/modules/products/nodes.repository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+
+export interface MatchingNode {
+  id: string;
+  host: string;
+  port: number;
+  type: string;
+}
+
+@Injectable()
+export class MatchingNodeRepository {
+  private readonly nodes: MatchingNode[] = [
+    { id: 'nodeA', host: 'localhost', port: 8081, type: 'AIEAN' },
+    { id: 'nodeB', host: 'localhost', port: 8082, type: 'OTHER' },
+  ];
+
+  findById(id: string): MatchingNode | undefined {
+    return this.nodes.find((node) => node.id === id);
+  }
+
+  findAll(): MatchingNode[] {
+    return [...this.nodes];
+  }
+}

--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+
+import { CreateProductDto } from './dto/create-product.dto';
+import { MatchProductDto } from './dto/match-product.dto';
+import { ProductsService } from './products.service';
+
+@Controller('products')
+export class ProductsController {
+  constructor(private readonly productsService: ProductsService) {}
+
+  @Post()
+  create(@Body() createProductDto: CreateProductDto) {
+    return this.productsService.create(createProductDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.productsService.findAll();
+  }
+
+  @Get(':ean')
+  findOne(@Param('ean') ean: string) {
+    return this.productsService.findOne(ean);
+  }
+
+  @Post('match')
+  matchProduct(@Body() matchProductDto: MatchProductDto) {
+    return this.productsService.matchProduct(
+      matchProductDto.product,
+      matchProductDto.nodeIds,
+    );
+  }
+}

--- a/src/modules/products/products.module.ts
+++ b/src/modules/products/products.module.ts
@@ -1,0 +1,15 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+
+import { MatchingService } from './matching.service';
+import { MatchingNodeRepository } from './nodes.repository';
+import { ProductsController } from './products.controller';
+import { ProductsService } from './products.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [ProductsController],
+  providers: [ProductsService, MatchingService, MatchingNodeRepository],
+  exports: [ProductsService],
+})
+export class ProductsModule {}

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { CreateProductDto } from './dto/create-product.dto';
+import { Product } from './entities/product.entity';
+import { MatchingService } from './matching.service';
+
+@Injectable()
+export class ProductsService {
+  private readonly products = new Map<string, Product>();
+
+  constructor(private readonly matchingService: MatchingService) {}
+
+  create(createProductDto: CreateProductDto): Product {
+    const product = Object.assign(new Product(), {
+      ...createProductDto,
+      scrapedate: new Date(createProductDto.scrapedate),
+    });
+
+    this.products.set(product.ean, product);
+    return product;
+  }
+
+  findAll(): Product[] {
+    return Array.from(this.products.values());
+  }
+
+  findOne(ean: string): Product {
+    const product = this.products.get(ean);
+    if (!product) {
+      throw new NotFoundException(`Product with EAN ${ean} not found`);
+    }
+    return product;
+  }
+
+  async matchProduct(product: CreateProductDto, nodeIds: string[]) {
+    const results = await this.matchingService.matchProduct(product, nodeIds);
+    return {
+      product,
+      results,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a Products module with DTOs, entity, controller, and service for CRUD operations
- implement MatchingService with static node repository, HTTP calls, and simulated fallbacks
- register the Products module in the application module to expose the new endpoints

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc329e0e14832eaec1b9493f62d19b